### PR TITLE
Support Oracle JDBC URLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,11 +63,13 @@ flyway_config:
     host: localhost
     port: 1521
     name: XE
-    user: GUT
-    password: mdp4gut
-  schemas: GUT
+    user: APP
+    password: appsecret
+  schemas: APP
 flyway_locations: filesystem:/opt/migrations/full,filesystem:/opt/migrations/demo
 ```
+
+Configuration tested with Oracle XE 11.
 
 License
 -------

--- a/README.md
+++ b/README.md
@@ -52,6 +52,22 @@ Example Playbook
             schemas: public, myschema
          - flyway_locations: /opt/migrations/
         
+Example configuration for Oracle
+--------------------------------
+
+```
+flyway_driver: oracle.jdbc.OracleDriver
+flyway_config:
+  database:
+    dbms: oracle
+    host: localhost
+    port: 1521
+    name: XE
+    user: GUT
+    password: mdp4gut
+  schemas: GUT
+flyway_locations: filesystem:/opt/migrations/full,filesystem:/opt/migrations/demo,filesystem:/opt/migrations/tomcat
+```
 
 License
 -------

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ flyway_config:
     user: GUT
     password: mdp4gut
   schemas: GUT
-flyway_locations: filesystem:/opt/migrations/full,filesystem:/opt/migrations/demo,filesystem:/opt/migrations/tomcat
+flyway_locations: filesystem:/opt/migrations/full,filesystem:/opt/migrations/demo
 ```
 
 License

--- a/README.md
+++ b/README.md
@@ -71,6 +71,14 @@ flyway_locations: filesystem:/opt/migrations/full,filesystem:/opt/migrations/dem
 
 Configuration tested with Oracle XE 11.
 
+Note: you need to copy the driver jar to flyway:
+
+```
+- name: Copy Oracle JDBC driver to machine Flyway folder
+  copy: src=./lib/ojdbc6-11.1.0.7.0.jar dest=/opt/flyway/flyway-{{ flyway_version }}/drivers
+  sudo: yes
+```
+
 License
 -------
 

--- a/templates/flyway.properties.j2
+++ b/templates/flyway.properties.j2
@@ -1,7 +1,11 @@
 {% if flyway_driver is defined -%}
     flyway.driver={{flyway_driver}}
 {% endif %}
+{% if flyway_config.database.dbms == 'oracle' -%}
+flyway.url=jdbc:{{flyway_config.database.dbms}}:thin:@{{flyway_config.database.host}}:{{flyway_config.database.port|default(1521)}}:{{flyway_config.database.name}}
+{% else -%}
 flyway.url=jdbc:{{flyway_config.database.dbms}}://{{flyway_config.database.host}}:{{flyway_config.database.port|default(5432)}}/{{flyway_config.database.name}}
+{% endif %}
 {% if flyway_config.database.user is defined -%}
     flyway.user={{flyway_config.database.user}}
 {% endif %}


### PR DESCRIPTION
Hi,

I try to use this playbook to install Flyway and do a migration on Oracle Express 11 on a Linux VM but i have a problem with the jdbc url which is forged in the templates/flyway.properties.js2 file. Specifically there is problem with the // to denote the host of the DB (i use a '@' instead). A patch will follow (with a condition on the driver name to construct the JDBC URL with @ if using oracle-thin. Please, let me know if i'm wrong,

Best regards
