### PR TITLE
Update meta/main.yml

### DIFF
--- a/meta/main.yml
+++ b/meta/main.yml
@@ -25,4 +25,4 @@ galaxy_info:
         - all
   categories:
     - database
-  dependencies: []
+dependencies: []


### PR DESCRIPTION
corrected 'dependencies' property

in previous version, it resulted in the following error :

> downloading role from https://github.com/amarao/ansible-flyway/archive/master.tar.gz
> extracting ansible-flyway to /etc/ansible/roles/ansible-flyway
> ansible-flyway was installed successfully
> Traceback (most recent call last):
>  File "/usr/local/bin/ansible-galaxy", line 959, in <module>
>    main()
>  File "/usr/local/bin/ansible-galaxy", line 953, in main
>    fn(args, options, parser)
>  File "/usr/local/bin/ansible-galaxy", line 845, in execute_install
>    role_dependencies = role_data['dependencies']
> KeyError: 'dependencies'
