### PR TITLE
Fix postgres typo user name

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -9,7 +9,7 @@ flyway_config:
     host: localhost
     port: 5432
     name: example
-    user: posrgres
+    user: postgres
     password: postgres
   schemas: public
 flyway_table: schema_history


### PR DESCRIPTION
Hi,

I've use your ansible playbook to install `flyway`. I've noticed a small typo for the default `Postgres` user name.

Cheers

Emmanuel