### PR TITLE
small typo: Add missing syntax for postgres example

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ Example Playbook (postgres)
          - flyway_config:
             database: 
               host: localhost
-              port 5432
+              port: 5432
               dbms: postgesql
               name: example
               user: postgres


### PR DESCRIPTION
Add a missing colon for dict entry in README.