### PR TITLE
Change default to current flyway

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ Example Playbook (postgres)
          - flyway_config:
             database: 
               host: localhost
-              port 5432
+              port: 5432
               dbms: postgesql
               name: example
               user: postgres

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Role Variables
 --------------
 All variables are optional
 
-- fly\_version: (default: "4.0")
+- fly\_version: (default: "4.2.0")
 - flyway\_download\_url: (default: "http://repo1.maven.org/maven2/org/flywaydb/flyway-commandline/%s/flyway-commandline-%s.tar.gz")
 - flyway\_root: (default: /opt/flyway)
 - flyway\_config: 
@@ -52,6 +52,8 @@ Example Playbook (postgres)
               password: postgres
             schemas: public, myschema
          - flyway_locations: filesystem:/opt/migrations/
+         
+Configuration tested with Postgres 9.2.
         
 Example Playbook (Oracle)
 -------------------------

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,5 +1,5 @@
 ---
-flyway_version: "4.0"
+flyway_version: "4.2.0"
 flyway_download_url: "http://repo1.maven.org/maven2/org/flywaydb/flyway-commandline/%s/flyway-commandline-%s.tar.gz"
 flyway_root: /opt/flyway
 flyway_symlink_location: /usr/bin


### PR DESCRIPTION
Flyway 4.2.0 has been out for a while, is battle tested, and plays nicer with latest postgres. I think it would be easier for general public to default to current version.