### PR TITLE
fix typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ Example Playbook (postgres)
             database: 
               host: localhost
               port: 5432
-              dbms: postgesql
+              dbms: postgresql
               name: example
               user: postgres
               password: postgres


### PR DESCRIPTION
currently `postgesql` is a typo and might confuse users who do c&p.