### PR TITLE
Enable https cert validation

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,7 +1,7 @@
 ---
 flyway_version: "5.0.1"
 flyway_download_url: "https://repo1.maven.org/maven2/org/flywaydb/flyway-commandline/%s/flyway-commandline-%s.tar.gz"
-# flyway_download_validate_certs: "yes"
+flyway_download_validate_certs: "yes"
 flyway_root: /opt/flyway
 flyway_symlink_location: /usr/bin
 flyway_config:

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,6 +1,7 @@
 ---
 flyway_version: "5.0.1"
-flyway_download_url: "http://repo1.maven.org/maven2/org/flywaydb/flyway-commandline/%s/flyway-commandline-%s.tar.gz"
+flyway_download_url: "https://repo1.maven.org/maven2/org/flywaydb/flyway-commandline/%s/flyway-commandline-%s.tar.gz"
+flyway_download_validate_certs: "yes"
 flyway_root: /opt/flyway
 flyway_symlink_location: /usr/bin
 flyway_config:

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,7 +1,7 @@
 ---
 flyway_version: "5.0.1"
 flyway_download_url: "https://repo1.maven.org/maven2/org/flywaydb/flyway-commandline/%s/flyway-commandline-%s.tar.gz"
-flyway_download_validate_certs: "yes"
+# flyway_download_validate_certs: "yes"
 flyway_root: /opt/flyway
 flyway_symlink_location: /usr/bin
 flyway_config:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -10,7 +10,7 @@
   get_url: 
     url: "{{flyway_real_url}}" 
     dest: "{{flyway_root}}"
-    validate_certs: {{flyway_download_validate_certs}}
+    validate_certs: "{{flyway_download_validate_certs}}"
   when: flyway_status.stat.mode|default(0) != "0755"
 
 - name: Unpack flyway

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -7,13 +7,10 @@
   file: path={{flyway_root}} state=directory
 
 - name: Download flyway
-  vars:
-    usessl: false
   get_url: 
     url: "{{flyway_real_url}}" 
     dest: "{{flyway_root}}"
-    validate_certs: "{{flyway_download_validate_certs}}"
-      when: usessl = "true"
+    validate_certs: "{{flyway_download_validate_certs | default(omit)}}"
   when: flyway_status.stat.mode|default(0) != "0755"
 
 - name: Unpack flyway

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -10,7 +10,6 @@
   get_url: 
     url: "{{flyway_real_url}}" 
     dest: "{{flyway_root}}"
-    validate_certs: "{{flyway_download_validate_certs | default(omit)}}"
   when: flyway_status.stat.mode|default(0) != "0755"
 
 - name: Unpack flyway

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -7,9 +7,11 @@
   file: path={{flyway_root}} state=directory
 
 - name: Download flyway
-  get_url: url={{flyway_real_url}} dest={{flyway_root}}
+  get_url: 
+    url: "{{flyway_real_url}}" 
+    dest: "{{flyway_root}}"
+    validate_certs: "{{flyway_download_validate_certs}}"
   when: flyway_status.stat.mode|default(0) != "0755"
-  validate_certs: "{{flyway_download_validate_certs}}"
 
 - name: Unpack flyway
   unarchive: copy=no src={{flyway_root}}/flyway-commandline-{{flyway_version}}.tar.gz dest={{flyway_root}} creates={{flyway_binary}}

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -8,7 +8,7 @@
 
 - name: Download flyway
   vars:
-    usessl: true
+    usessl: false
   get_url: 
     url: "{{flyway_real_url}}" 
     dest: "{{flyway_root}}"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -9,7 +9,7 @@
 - name: Download flyway
   get_url: url={{flyway_real_url}} dest={{flyway_root}}
   when: flyway_status.stat.mode|default(0) != "0755"
-  validate_certs: {{flyway_download_validate_certs}}
+  validate_certs: "{{flyway_download_validate_certs}}"
 
 - name: Unpack flyway
   unarchive: copy=no src={{flyway_root}}/flyway-commandline-{{flyway_version}}.tar.gz dest={{flyway_root}} creates={{flyway_binary}}

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -7,10 +7,13 @@
   file: path={{flyway_root}} state=directory
 
 - name: Download flyway
+  vars:
+    usessl: true
   get_url: 
     url: "{{flyway_real_url}}" 
     dest: "{{flyway_root}}"
     validate_certs: "{{flyway_download_validate_certs}}"
+      when: usessl = "true"
   when: flyway_status.stat.mode|default(0) != "0755"
 
 - name: Unpack flyway

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -10,6 +10,7 @@
   get_url: 
     url: "{{flyway_real_url}}" 
     dest: "{{flyway_root}}"
+    validate_certs: {{flyway_download_validate_certs}}
   when: flyway_status.stat.mode|default(0) != "0755"
 
 - name: Unpack flyway

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -9,6 +9,7 @@
 - name: Download flyway
   get_url: url={{flyway_real_url}} dest={{flyway_root}}
   when: flyway_status.stat.mode|default(0) != "0755"
+  validate_certs: {{flyway_download_validate_certs}}
 
 - name: Unpack flyway
   unarchive: copy=no src={{flyway_root}}/flyway-commandline-{{flyway_version}}.tar.gz dest={{flyway_root}} creates={{flyway_binary}}

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -1,3 +1,4 @@
 ---
 flyway_real_url: "{{ flyway_download_url | format(flyway_version, flyway_version) }}"
 flyway_binary: "{{flyway_root}}/flyway-{{flyway_version}}/flyway"
+usessl: "true"


### PR DESCRIPTION
Enable https cert validation for https sites, also enables the ability to disable it for locally hosted self cert flyway repos.